### PR TITLE
Create teamId to GM name mapping

### DIFF
--- a/src/screens/dynasty/DynastyBasketballStandings.js
+++ b/src/screens/dynasty/DynastyBasketballStandings.js
@@ -10,7 +10,7 @@ import {
   DynastyStandingsColumns,
 } from "./StandingsColumns";
 import { assignRankPoints } from "utils/standings";
-import { HIGH_TO_LOW } from "Constants";
+import { ERA_1, HIGH_TO_LOW } from "Constants";
 import { useSelector } from "react-redux";
 
 export const DynastyBasketballStandings = () => {
@@ -38,8 +38,17 @@ export const DynastyBasketballStandings = () => {
 
       const scrape = async (collection) => {
         const leagueId = leagueIdMappings[sportYear];
+        const gmNamesIdsCollection = await returnMongoCollection(
+          "gmNamesIds",
+          ERA_1
+        );
+        const gmNamesIds = await gmNamesIdsCollection.find({ leagueId });
+        const gmNamesIdsMapping = gmNamesIds?.[0]?.mappings ?? {};
         const tableStandings = await standingsScraper(leagueId);
-        const divisionStandings = formatScrapedStandings(tableStandings);
+        const divisionStandings = formatScrapedStandings(
+          tableStandings,
+          gmNamesIdsMapping
+        );
         const dynastyStandings = assignRankPoints(
           Object.values(divisionStandings).flat(1),
           "winPer",

--- a/src/screens/dynasty/StandingsHelper.js
+++ b/src/screens/dynasty/StandingsHelper.js
@@ -26,7 +26,11 @@ export const standingsScraper = async (leagueId) => {
   return tableStandings;
 };
 
-export const formatScrapedStandings = (standings, isFootball = false) => {
+export const formatScrapedStandings = (
+  standings,
+  namesIdsObject,
+  isFootball = false
+) => {
   const globalDivisionStandings = {};
 
   for (let i = 0; i < standings.length; i++) {
@@ -36,8 +40,11 @@ export const formatScrapedStandings = (standings, isFootball = false) => {
 
     for (let j = 0; j < eachDivision.rows.length; j++) {
       const eachTeam = eachDivision.rows[j];
+
+      const gmName = namesIdsObject[eachTeam.fixedCells[1].teamId];
       const divStandingsObj = {
         teamName: eachTeam.fixedCells[1].content,
+        gm: gmName ?? "N/A",
         wins: eachTeam.cells[0].content,
         losses: eachTeam.cells[1].content,
         ties: eachTeam.cells[2].content,


### PR DESCRIPTION
Need mapping in mongoDB for each league, each team gets a new teamId for each new sport & season